### PR TITLE
New layout system

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Nev is still relatively new, so many things are still missing or need improvemen
 - [Sessions](docs/sessions.md)
 - [WASM plugins](docs/configuration.md)
 - Basic git integration (list/diff/add/stage/unstage/revert changed files)
+- [Builtin terminal emulator](docs/docs.md#Terminal) support multiple shells (e.g `bash`, `powershell`, `wsl`)
 - And many more smaller features...
 
 ## Planned features

--- a/config/settings.json
+++ b/config/settings.json
@@ -803,4 +803,11 @@
         "command": "wezterm",
         "args": ["cli", "split-pane", "--right", "--", ["exe"] , ["args"], "--terminal"],
     },
+
+    "layout": {
+        "kind": "main",
+        "center": {
+            "kind": "tab",
+        },
+     },
 }

--- a/scripting/editor_api_wasm.nim
+++ b/scripting/editor_api_wasm.nim
@@ -594,13 +594,6 @@ proc reloadTheme*() {.gcsafe, raises: [].} =
   let res {.used.} = editor_reloadTheme_void_App_wasm(argsJsonString.cstring)
 
 
-proc editor_reloadState_void_App_wasm(arg: cstring): cstring {.importc.}
-proc reloadState*() {.gcsafe, raises: [].} =
-  var argsJson = newJArray()
-  let argsJsonString = $argsJson
-  let res {.used.} = editor_reloadState_void_App_wasm(argsJsonString.cstring)
-
-
 proc editor_saveSession_void_App_string_wasm(arg: cstring): cstring {.importc.}
 proc saveSession*(sessionFile: string = "") {.gcsafe, raises: [].} =
   var argsJson = newJArray()

--- a/scripting/layout_api_wasm.nim
+++ b/scripting/layout_api_wasm.nim
@@ -4,16 +4,6 @@ import scripting_api, misc/myjsonutils
 ## This file is auto generated, don't modify.
 
 
-proc layout_setLayout_void_LayoutService_string_wasm(arg: cstring): cstring {.
-    importc.}
-proc setLayout*(layout: string) {.gcsafe, raises: [].} =
-  var argsJson = newJArray()
-  argsJson.add layout.toJson()
-  let argsJsonString = $argsJson
-  let res {.used.} = layout_setLayout_void_LayoutService_string_wasm(
-      argsJsonString.cstring)
-
-
 proc layout_changeLayoutProp_void_LayoutService_string_float32_wasm(arg: cstring): cstring {.
     importc.}
 proc changeLayoutProp*(prop: string; change: float32) {.gcsafe, raises: [].} =

--- a/src/misc/jsonex.nim
+++ b/src/misc/jsonex.nim
@@ -1211,7 +1211,7 @@ proc raiseJsonException(condStr: string, msg: string) {.noinline.} =
   # JsonError, JsonParser, JsonKindError
   raise newException(ValueError, condStr & " failed: " & msg)
 
-template checkJson(cond: untyped, msg = "") =
+template checkJson*(cond: untyped, msg = "") =
   if not cond:
     raiseJsonException(astToStr(cond), msg)
 

--- a/src/misc/myjsonutils.nim
+++ b/src/misc/myjsonutils.nim
@@ -566,3 +566,17 @@ proc extendJson*(a: var JsonNode, b: JsonNode, extend: bool) =
 
   else:
     a = b
+
+proc shallowCopy*(p: JsonNode): JsonNode =
+  ## Performs a shallow copy of `p`.
+  case p.kind
+  of JString, JInt, JFloat, JBool, JNull:
+    result = p.copy()
+  of JObject:
+    result = newJObject()
+    for key, val in pairs(p.fields):
+      result.fields[key] = val
+  of JArray:
+    result = newJArray()
+    for i in items(p.elems):
+      result.elems.add(i)

--- a/src/session.nim
+++ b/src/session.nim
@@ -1,5 +1,5 @@
 import std/[strutils, options, json, tables]
-import misc/[custom_async, custom_logger, util, myjsonutils, event]
+import misc/[custom_async, custom_logger, util, myjsonutils, event, id]
 import scripting/expose
 import dispatch_tables, service
 
@@ -13,6 +13,12 @@ type
     sessionData*: JsonNode
     onSessionRestored*: Event[SessionService]
     hasSession*: bool
+    sessionSaveHandlers: seq[tuple[
+      id: Id,
+      key: string,
+      save: proc(): JsonNode {.gcsafe, raises: [].},
+      load: proc(data: JsonNode) {.gcsafe, raises: [].},
+    ]]
 
 func serviceName*(_: typedesc[SessionService]): string = "SessionService"
 addBuiltinService(SessionService)
@@ -23,9 +29,36 @@ method init*(self: SessionService): Future[Result[void, ref CatchableError]] {.a
   return ok()
 
 proc restoreSession*(self: SessionService, sessionData: JsonNode) =
+  debugf"SessionService.restoreSession"
   self.sessionData = sessionData
+  if self.sessionData.hasKey("dynamic"):
+    let dynamic = self.sessionData["dynamic"]
+    if dynamic.kind == JObject:
+      for handler in self.sessionSaveHandlers:
+        if dynamic.hasKey(handler.key):
+          handler.load(dynamic[handler.key])
+    else:
+      log lvlError, &"Invalid data in session data: '{dynamic}' should be an object"
+
   self.onSessionRestored.invoke(self)
   self.hasSession = true
+
+proc addSaveHandler*(self: SessionService, key: string,
+    save: proc(): JsonNode {.gcsafe, raises: [].},
+    load: proc(data: JsonNode) {.gcsafe, raises: [].}) =
+  self.sessionSaveHandlers.add (newId(), key, save, load)
+
+proc saveSession*(self: SessionService): JsonNode =
+  debugf"SessionService.saveSession"
+  result = self.sessionData.shallowCopy()
+  if result == nil:
+    result = newJObject()
+  var dynamic = newJObject()
+  for saveHandler in self.sessionSaveHandlers:
+    let data = saveHandler.save()
+    if data != nil:
+      dynamic[saveHandler.key] = data
+  result["dynamic"] = dynamic
 
 ###########################################################################
 

--- a/themes/green.json
+++ b/themes/green.json
@@ -13,7 +13,7 @@
         "editor.findMatchBackground": "#89895966",
         "editorCursor.foreground": "#ABB2BF",
         "editorCursor.background": "#102121",
-        "tab.activeBackground": "#0D2525",
+        "tab.activeBackground": "#1D312F",
         "tab.inactiveBackground": "#102121",
         "focusBorder": "#2D4545",
         "breadcrumbPicker.background": "#152323",


### PR DESCRIPTION
# Old behaviour
- choose one of three automatic layouts (`horizontal`, `vertical`, `alternating`)

# New behaviour
- More layout options: (`horizontal`, `vertical`, `alternating`, `main`, `tab`, `split`)
- `main` layout has five slots (`center`, `left`, `right`, `top`, `bottom`)
- `split` layout allows creating arbitrary splits (like in Vim)
- layouts can be nested (e.g. splits inside of tabs (like Vim), or tabs inside splits (like VS Code)
- more commands for navigating between open views (directions, prev/next, focus specific slot)
- more control over where to open new views (in new tab, in split, center/left/right etc)