### PR TITLE
Add initial font configuration

### DIFF
--- a/config/settings.schema.json
+++ b/config/settings.schema.json
@@ -317,6 +317,26 @@
                     "type": "string",
                     "description": "Path to theme to be used.",
                     "default": "app://themes/tokyo-night-color-theme.json"
+                },
+                "^fontFamily$": {
+                    "type": "string",
+                    "description": "Full path to regular font file.",
+                    "default": "app://fonts/DejaVuSansMono.ttf"
+                },
+                "^fontFamilyBold$": {
+                    "type": "string", 
+                    "description": "Full path to bold font file.",
+                    "default": "app://fonts/DejaVuSansMono-Bold.ttf"
+                },
+                "^fontFamilyItalic$": {
+                    "type": "string",
+                    "description": "Full path to italic font file.", 
+                    "default": "app://fonts/DejaVuSansMono-Oblique.ttf"
+                },
+                "^fontFamilyBoldItalic$": {
+                    "type": "string",
+                    "description": "Full path to bold italic font file.",
+                    "default": "app://fonts/DejaVuSansMono-BoldOblique.ttf"
                 }
             }
         },

--- a/docs/settings.gen.md
+++ b/docs/settings.gen.md
@@ -107,6 +107,10 @@ For examples and default values see [here](../config/settings.json)
 | `ui.background.transparent` | bool | false | If true the background is transparent. |
 | `ui.cursor-trail-length` | int | 2 | How long the cursor trail is. Set to 0 to disable cursor trail. |
 | `ui.cursor-trail-speed` | float | 100.0 | How fast to interpolate the cursor trail position when moving the cursor. Higher means faster. |
+| `ui.font-family` | string | "app://fonts/DejaVuSansMono.ttf" | Full path to regular font file. |
+| `ui.font-family-bold` | string | "app://fonts/DejaVuSansMono-Bold.ttf" | Full path to bold font file. |
+| `ui.font-family-bold-italic` | string | "app://fonts/DejaVuSansMono-BoldOblique.ttf" | Full path to bold italic font file. |
+| `ui.font-family-italic` | string | "app://fonts/DejaVuSansMono-Oblique.ttf" | Full path to italic font file. |
 | `ui.hide-tab-bar-when-single` | bool | false | When true then tab layouts don't render a tab bar when they only have one tab. |
 | `ui.indent-guide` | bool | true | Enable indent guides to show the indentation of the current line. |
 | `ui.line-numbers` | "none" \| "absolute" \| "relative" | "absolute" | How line numbers should be displayed. |

--- a/src/app.nim
+++ b/src/app.nim
@@ -763,6 +763,23 @@ proc applySettingsFromAppOptions(self: App) =
     log lvlInfo, &"Set {setting}"
     self.config.runtime.set(path, value)
 
+proc applyFontSettings(self: App) =
+  let fontRegular = self.uiSettings.fontFamily.get
+  let fontBold = self.uiSettings.fontFamilyBold.get  
+  let fontItalic = self.uiSettings.fontFamilyItalic.get
+  let fontBoldItalic = self.uiSettings.fontFamilyBoldItalic.get
+  
+  if fontRegular != self.fontRegular or
+     fontBold != self.fontBold or
+     fontItalic != self.fontItalic or
+     fontBoldItalic != self.fontBoldItalic:
+    log lvlInfo, &"Applying font settings: {fontRegular}, {fontBold}, {fontItalic}, {fontBoldItalic}"
+    self.fontRegular = fontRegular
+    self.fontBold = fontBold
+    self.fontItalic = fontItalic  
+    self.fontBoldItalic = fontBoldItalic
+    self.platform.setFont(self.fontRegular, self.fontBold, self.fontItalic, self.fontBoldItalic, self.fallbackFonts)
+
 proc runEarlyCommandsFromAppOptions(self: App) =
   log lvlInfo, &"Run early commands provided through command line"
   for command in self.appOptions.earlyCommands:
@@ -837,10 +854,6 @@ proc newApp*(backend: api.Backend, platform: Platform, services: Services, optio
   self.platform.fontSize = 16
   self.platform.lineDistance = 4
 
-  self.fontRegular = "app://fonts/DejaVuSansMono.ttf"
-  self.fontBold = "app://fonts/DejaVuSansMono-Bold.ttf"
-  self.fontItalic = "app://fonts/DejaVuSansMono-Oblique.ttf"
-  self.fontBoldItalic = "app://fonts/DejaVuSansMono-BoldOblique.ttf"
   self.fallbackFonts.add "app://fonts/Noto_Sans_Symbols_2/NotoSansSymbols2-Regular.ttf"
   self.fallbackFonts.add "app://fonts/NotoEmoji/NotoEmoji.otf"
 
@@ -860,6 +873,8 @@ proc newApp*(backend: api.Backend, platform: Platform, services: Services, optio
 
   self.uiSettings = UiSettings.new(self.config.runtime)
   self.generalSettings = GeneralSettings.new(self.config.runtime)
+
+  self.applyFontSettings()
 
   self.themes.setTheme(defaultTheme())
 
@@ -937,6 +952,8 @@ proc newApp*(backend: api.Backend, platform: Platform, services: Services, optio
   discard self.config.runtime.onConfigChanged.subscribe proc(key: string) =
     if key == "" or key == "ui" or key == "ui.theme":
       self.reloadThemeFromConfig = true
+    if key == "" or key == "ui" or key.startsWith("ui.font-family"):
+      self.applyFontSettings()
 
   if not options.dontRestoreConfig:
     if options.sessionOverride.getSome(session):

--- a/src/config_provider.nim
+++ b/src/config_provider.nim
@@ -1002,6 +1002,18 @@ declareSettings UiSettings, "ui":
   ## VFS path of the theme.
   declare theme, string, "app://themes/tokyo-night-color-theme.json"
 
+  ## Full path to regular font file.
+  declare fontFamily, string, "app://fonts/DejaVuSansMono.ttf"
+
+  ## Full path to bold font file.
+  declare fontFamilyBold, string, "app://fonts/DejaVuSansMono-Bold.ttf"
+
+  ## Full path to italic font file.
+  declare fontFamilyItalic, string, "app://fonts/DejaVuSansMono-Oblique.ttf"
+
+  ## Full path to bold italic font file.
+  declare fontFamilyBoldItalic, string, "app://fonts/DejaVuSansMono-BoldOblique.ttf"
+
   ## After how many milliseconds the which key window opens.
   declare whichKeyDelay, int, 250
 


### PR DESCRIPTION
This PR adds some initial font configuration. Just include in your config e.g.:

```json
  {
    "ui": {
      "font-family": "/usr/share/fonts/truetype/firacode/FiraCode-Regular.ttf",
      "font-family-bold": "/usr/share/fonts/truetype/firacode/FiraCode-Bold.ttf",
      "font-family-italic": "/usr/share/fonts/truetype/firacode/FiraCode-Light.ttf",
      "font-family-bold-italic": "/usr/share/fonts/truetype/firacode/FiraCode-Medium.ttf"
    }
  }
```

Hot reloading on config change also works. Only tested on Linux.